### PR TITLE
Fixing Syntax Error on Persistent Menu Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Facebook::Messenger::Profile.set({
           type: 'nested',
           call_to_actions: [
             {
-              title: 'What's a chatbot?',
+              title: 'What is a chatbot?',
               type: 'postback',
               payload: 'EXTERMINATE'
             },


### PR DESCRIPTION
This fixed the syntax error caused by a single quote on the persistent menu example.