### PR TITLE
Feature/messaging type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Bot.deliver({
   },
   message: {
     text: 'Human?'
-  }
+  },
+  message_type: Facebook::Messenger::Bot::MessageType::UPDATE
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
 

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -1,5 +1,6 @@
 require 'facebook/messenger/bot/error_parser'
 require 'facebook/messenger/bot/exceptions'
+require 'facebook/messenger/bot/message_type'
 
 module Facebook
   module Messenger

--- a/lib/facebook/messenger/bot/message_type.rb
+++ b/lib/facebook/messenger/bot/message_type.rb
@@ -1,0 +1,13 @@
+module Facebook
+  module Messenger
+    module Bot
+      # Supported message types
+      module MessageType
+        RESPONSE = "RESPONSE".freeze
+        UPDATE = "UPDATE".freeze
+        MESSAGE_TAG = "MESSAGE_TAG".freeze
+        NON_PROMOTIONAL_SUBSCRIPTION = "NON_PROMOTIONAL_SUBSCRIPTION".freeze
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -51,7 +51,8 @@ module Facebook
         def reply(message)
           payload = {
             recipient: sender,
-            message: message
+            message: message,
+            message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
           }
 
           Facebook::Messenger::Bot.deliver(payload, access_token: access_token)

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -131,6 +131,7 @@ describe Facebook::Messenger::Bot do
 
     let(:payload) do
       {
+        messaging_type: "RESPONSE",
         recipient: {
           id: '123'
         },

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -109,7 +109,7 @@ describe Dummy do
   describe '.reply' do
     let(:access_token) { 'access_token' }
 
-    it 'replies to the sender' do
+    it 'replies to the sender with the default message type' do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
@@ -117,7 +117,8 @@ describe Dummy do
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
                 recipient: subject.sender,
-                message: { text: 'Hello, human' }
+                message: { text: 'Hello, human' },
+                message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
               }, access_token: access_token)
 
       subject.reply(text: 'Hello, human')


### PR DESCRIPTION
Fixes #185 
Adds support for the `message_type`attribute required in Messenger 2.2

