### PR TITLE
Add prior_message to Incoming::Common

### DIFF
--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -17,6 +17,15 @@ module Facebook
           @messaging['recipient']
         end
 
+        # https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin
+        # If the user responds to your message, the appropriate event (messages, messaging_postbacks, etc.) 
+        # will be sent to your webhook, with a prior_message object appended. The prior_message object includes 
+        # the source of the message the user is responding to, as well as the user_ref used for the 
+        # original message send.
+        def prior_message
+          @messaging['prior_message']
+        end
+
         def sent_at
           Time.at(@messaging['timestamp'] / 1000)
         end

--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -17,11 +17,11 @@ module Facebook
           @messaging['recipient']
         end
 
-        # https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin
-        # If the user responds to your message, the appropriate event (messages, messaging_postbacks, etc.) 
-        # will be sent to your webhook, with a prior_message object appended. The prior_message object includes 
-        # the source of the message the user is responding to, as well as the user_ref used for the 
-        # original message send.
+        # If the user responds to your message, the appropriate event 
+        # (messages, messaging_postbacks, etc.) will be sent to your webhook,
+        # with a prior_message object appended. The prior_message object 
+        # includes the source of the message the user is responding to, as well
+        # as the user_ref used for the original message send.
         def prior_message
           @messaging['prior_message']
         end

--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -17,9 +17,9 @@ module Facebook
           @messaging['recipient']
         end
 
-        # If the user responds to your message, the appropriate event 
+        # If the user responds to your message, the appropriate event
         # (messages, messaging_postbacks, etc.) will be sent to your webhook,
-        # with a prior_message object appended. The prior_message object 
+        # with a prior_message object appended. The prior_message object
         # includes the source of the message the user is responding to, as well
         # as the user_ref used for the original message send.
         def prior_message

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -28,6 +28,10 @@ describe Dummy do
             'url' => 'https://www.example.com/1.jpg'
           }
         }]
+      },
+      'prior_message' => {
+        'source' => 'checkbox_plugin',        
+        'identifier' => '903dac41-0976-467f-805e-ed58dc23a783'
       }
     }
   end
@@ -43,6 +47,12 @@ describe Dummy do
   describe '.recipient' do
     it 'returns the recipient' do
       expect(subject.recipient).to eq(payload['recipient'])
+    end
+  end
+
+  describe '.prior_message' do
+    it 'returns the message' do
+      expect(subject.prior_message).to eq(payload['prior_message'])
     end
   end
 

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -30,7 +30,7 @@ describe Dummy do
         }]
       },
       'prior_message' => {
-        'source' => 'checkbox_plugin',        
+        'source' => 'checkbox_plugin',
         'identifier' => '903dac41-0976-467f-805e-ed58dc23a783'
       }
     }


### PR DESCRIPTION
Per the [Facebook Checkbox Plugin Docs](https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin)

> 7. Handle the user response
> If the user responds to your message, the appropriate event (messages, messaging_postbacks, etc.) will be sent to your webhook, with a prior_message object appended. The prior_message object includes the source of the message the user is responding to, as well as the user_ref used for the original message send.

Adding that `prior_message` method to the `Facebook::Messenger::Incoming::Common` module for easy access to that messaging info, if available.
