### PR TITLE
Handle policy enforcement webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,19 @@ Facebook::Messenger::Profile.set({
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
 
+
+#### Handle a Facebook Policy Violation
+
+See Facebook's documentation on [Messaging Policy Enforcement](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_policy_enforcement)
+
+```
+Bot.on :'policy-enforcement' do |referral|
+  referral.action # => 'block'
+  referral.reason # => "The bot violated our Platform Policies (https://developers.facebook.com/policy/#messengerplatform). Common violations include sending out excessive spammy messages or being non-functional."
+end
+```
+
+
 ## Configuration
 
 ### Create an Application on Facebook

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -20,6 +20,7 @@ module Facebook
         referral
         message_echo
         payment
+        policy-enforcement
       ].freeze
 
       class << self

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -9,6 +9,7 @@ require 'facebook/messenger/incoming/read'
 require 'facebook/messenger/incoming/account_linking'
 require 'facebook/messenger/incoming/referral'
 require 'facebook/messenger/incoming/payment'
+require 'facebook/messenger/incoming/policy_enforcement'
 
 module Facebook
   module Messenger
@@ -25,7 +26,8 @@ module Facebook
         'referral' => Referral,
         'message_echo' => MessageEcho,
         'message_request' => MessageRequest,
-        'payment' => Payment
+        'payment' => Payment,
+        'policy-enforcement' => PolicyEnforcement
       }.freeze
 
       # Parse the given payload.

--- a/lib/facebook/messenger/incoming/policy_enforcement.rb
+++ b/lib/facebook/messenger/incoming/policy_enforcement.rb
@@ -1,0 +1,17 @@
+module Facebook
+  module Messenger
+    module Incoming
+      class PolicyEnforcement
+        include Facebook::Messenger::Incoming::Common
+
+        def action
+          @messaging['policy-enforcement']['action']
+        end
+
+        def reason
+          @messaging['policy-enforcement']['reason']
+        end
+      end
+    end
+  end
+end

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -103,6 +103,20 @@ describe Facebook::Messenger::Bot do
         subject.receive({})
       end
     end
+
+    context 'with a policy-violation' do
+      let(:policy_enforcement) { Facebook::Messenger::Incoming::PolicyEnforcement.new({}) }
+
+      it 'triggers a :policy-enforcement' do
+        expect(Facebook::Messenger::Incoming).to receive(:parse)
+          .and_return(policy_enforcement)
+
+        expect(Facebook::Messenger::Bot).to receive(:trigger)
+          .with(:'policy-enforcement', policy_enforcement)
+
+        subject.receive({})
+      end
+    end
   end
 
   describe '.trigger' do

--- a/spec/facebook/messenger/incoming/policy_enforcement_spec.rb
+++ b/spec/facebook/messenger/incoming/policy_enforcement_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Facebook::Messenger::Incoming::PolicyEnforcement do
+  let :payload do
+    {
+      'sender' => {
+        'id' => '3'
+      },
+      'recipient' => {
+        'id' => '3'
+      },
+      'timestamp' => 145_776_419_762_7,
+      'policy-enforcement' => {
+        'action' => 'block',
+        'reason' => 'The bot violated our Platform Policies (https://developers.facebook.com/policy/#messengerplatform). Common violations include sending out excessive spammy messages or being non-functional.'
+      }
+    }
+  end
+
+  subject { described_class.new(payload) }
+
+  describe '.action' do
+    specify { expect(subject.action).to eq(payload['policy-enforcement']['action']) }
+  end
+
+  describe '.reason' do
+    specify {  expect(subject.reason).to eq(payload['policy-enforcement']['reason']) }
+  end
+end


### PR DESCRIPTION
https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_policy_enforcement

> A policy enforcement will be taken on a page if it does not conform to Messenger Platform policy, fails to meet Facebook community standards or violates Facebook Pages guidelines. Common issues include spams, sending inappropriate messages (porn, suicide, etc), abusing tags, etc.

This PR adds the ability to listen for this webhook and act on it.