### PR TITLE
update version of fb api to 2.9

### DIFF
--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -11,7 +11,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v2.6/me'
+      base_uri 'https://graph.facebook.com/v2.9/me'
 
       #
       # @return [Array] Array containing the supported webhook events.

--- a/lib/facebook/messenger/profile.rb
+++ b/lib/facebook/messenger/profile.rb
@@ -10,7 +10,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v2.6/me'
+      base_uri 'https://graph.facebook.com/v2.9/me'
 
       format :json
 

--- a/lib/facebook/messenger/subscriptions.rb
+++ b/lib/facebook/messenger/subscriptions.rb
@@ -9,7 +9,7 @@ module Facebook
     module Subscriptions
       include HTTParty
 
-      base_uri 'https://graph.facebook.com/v2.6/me'
+      base_uri 'https://graph.facebook.com/v2.9/me'
 
       format :json
 


### PR DESCRIPTION
There don't seem to be any messenger-related API changes from v2.6 to v2.9, but I have found that updating the version resolves the issue https://github.com/jgorset/facebook-messenger/issues/205 for me. Technically, we could update to v2.12 (the latest), but if you want to be conservative, I've split the difference and updated to 2.9 here.

The gem will have to update from v2.6 by July 2018 because that will be when v2.6 will no longer be available. Bumping to v2.9 will at least make sure the apis used by the gem are supported until July 2019.