### PR TITLE
Fix typo for messaging types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Bot.deliver({
   message: {
     text: 'Human?'
   },
-  message_type: Facebook::Messenger::Bot::MessageType::UPDATE
+  messaging_type: Facebook::Messenger::Bot::MessageType::UPDATE
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
 


### PR DESCRIPTION
According to [Messaging types documentation](https://developers.facebook.com/docs/messenger-platform/send-messages/#messaging_types) it's not `message_type` but `messaging_type`