### PR TITLE
#231 The parameter subscribed_fields is required

### DIFF
--- a/lib/facebook/messenger/subscriptions.rb
+++ b/lib/facebook/messenger/subscriptions.rb
@@ -27,9 +27,10 @@ module Facebook
       #
       # @return [Boolean] TRUE
       #
-      def subscribe(access_token:)
+      def subscribe(access_token:, subscription_fields: [])
         response = post '/subscribed_apps', query: {
-          access_token: access_token
+          access_token: access_token,
+          subscription_fields: subscription_fields
         }
 
         raise_errors(response)

--- a/lib/facebook/messenger/version.rb
+++ b/lib/facebook/messenger/version.rb
@@ -2,6 +2,6 @@ module Facebook
   module Messenger
     #
     # @return [String] Define the version of gem.
-    VERSION = '1.1.1'.freeze
+    VERSION = '1.1.2'.freeze
   end
 end

--- a/spec/facebook/messenger/subscriptions_spec.rb
+++ b/spec/facebook/messenger/subscriptions_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Facebook::Messenger::Subscriptions do
   let(:access_token) { 'access token' }
+  let(:subscribed_fields) { ['feed', 'mention', 'name'] }
 
   let(:subscribed_apps_url) do
     Facebook::Messenger::Subscriptions.base_uri + '/subscribed_apps'
@@ -15,7 +16,7 @@ describe Facebook::Messenger::Subscriptions do
     context 'with a successful response' do
       before do
         stub_request(:post, subscribed_apps_url)
-          .with(query: { access_token: access_token })
+          .with(query: { access_token: access_token, subscription_fields: subscribed_fields })
           .to_return(
             body: JSON.dump('success' => true),
             status: 200,
@@ -24,7 +25,7 @@ describe Facebook::Messenger::Subscriptions do
       end
 
       it 'returns true' do
-        expect(subject.subscribe(access_token: access_token)).to be true
+        expect(subject.subscribe(access_token: access_token, subscription_fields: subscribed_fields)).to be true
       end
     end
 
@@ -33,7 +34,7 @@ describe Facebook::Messenger::Subscriptions do
 
       before do
         stub_request(:post, subscribed_apps_url)
-          .with(query: { access_token: access_token })
+          .with(query: { access_token: access_token, subscription_fields: subscribed_fields })
           .to_return(
             body: JSON.dump(
               'error' => {
@@ -50,7 +51,7 @@ describe Facebook::Messenger::Subscriptions do
 
       it 'raises an error' do
         expect do
-          subject.subscribe(access_token: access_token)
+          subject.subscribe(access_token: access_token, subscription_fields: subscribed_fields)
         end.to raise_error(
           Facebook::Messenger::Subscriptions::Error, error_message
         )

--- a/spec/facebook/messenger/subscriptions_spec.rb
+++ b/spec/facebook/messenger/subscriptions_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Facebook::Messenger::Subscriptions do
   let(:access_token) { 'access token' }
-  let(:subscribed_fields) { ['feed', 'mention', 'name'] }
+  let(:subscr_fields) { %w[feed mention name] }
 
   let(:subscribed_apps_url) do
     Facebook::Messenger::Subscriptions.base_uri + '/subscribed_apps'
@@ -16,7 +16,10 @@ describe Facebook::Messenger::Subscriptions do
     context 'with a successful response' do
       before do
         stub_request(:post, subscribed_apps_url)
-          .with(query: { access_token: access_token, subscription_fields: subscribed_fields })
+          .with(query: {
+                  access_token: access_token,
+                  subscription_fields: subscr_fields
+                })
           .to_return(
             body: JSON.dump('success' => true),
             status: 200,
@@ -25,7 +28,8 @@ describe Facebook::Messenger::Subscriptions do
       end
 
       it 'returns true' do
-        expect(subject.subscribe(access_token: access_token, subscription_fields: subscribed_fields)).to be true
+        expect(subject.subscribe(access_token: access_token,
+                                 subscription_fields: subscr_fields)).to be true
       end
     end
 
@@ -34,7 +38,10 @@ describe Facebook::Messenger::Subscriptions do
 
       before do
         stub_request(:post, subscribed_apps_url)
-          .with(query: { access_token: access_token, subscription_fields: subscribed_fields })
+          .with(query: {
+                  access_token: access_token,
+                  subscription_fields: subscr_fields
+                })
           .to_return(
             body: JSON.dump(
               'error' => {
@@ -51,7 +58,8 @@ describe Facebook::Messenger::Subscriptions do
 
       it 'raises an error' do
         expect do
-          subject.subscribe(access_token: access_token, subscription_fields: subscribed_fields)
+          subject.subscribe(access_token: access_token,
+                            subscription_fields: subscr_fields)
         end.to raise_error(
           Facebook::Messenger::Subscriptions::Error, error_message
         )


### PR DESCRIPTION
Added defined param `subscription_fields` to `Facebook::Messenger::Subscriptions.subscribe` method
please, check: https://developers.facebook.com/docs/graph-api/reference/page/subscribed_apps#Creating