### PR TITLE
Add ad_id field to referral nested class

### DIFF
--- a/lib/facebook/messenger/incoming/referral.rb
+++ b/lib/facebook/messenger/incoming/referral.rb
@@ -27,6 +27,11 @@ module Facebook
           def type
             @referral['type']
           end
+
+          # Return String of ad id.
+          def ad_id
+            @referral['ad_id']
+          end
         end
 
         def referral

--- a/lib/facebook/messenger/incoming/referral.rb
+++ b/lib/facebook/messenger/incoming/referral.rb
@@ -30,7 +30,7 @@ module Facebook
 
           # Return String of ad id.
           def ad_id
-            @referral['ad_id']
+            @referral['ad_id'] if @referral.key?('ad_id')
           end
         end
 


### PR DESCRIPTION
I just added the following to the class Facebook::Messenger::Incoming::Referral::Referral:

```
          def ad_id
            @referral['ad_id'] if @referral.key?('ad_id')
          end
```

Is to have access to the ad_id when the ad_source is ADS
