### PR TITLE
Feature/integrate app secret proof and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Bot.deliver({
     text: 'Human?'
   },
   message_type: Facebook::Messenger::Bot::MessagingType::UPDATE
-}, access_token: ENV['ACCESS_TOKEN'])
+}, access_token: ENV['ACCESS_TOKEN'], app_secret_proof: app_secret_proof)
+```
+NOTE: for a provider you can get the `app_secret_proof` (from the credential_provider, which will cache it for you) like so:
+```
+credential_provider = Facebook::Messenger::Configuration::Providers::Environment.new
+app_secret_proof = credential_provider.app_secret_proof_for(page_id)
 ```
 
 ##### Messages with images

--- a/README.md
+++ b/README.md
@@ -48,13 +48,15 @@ Bot.deliver({
     text: 'Human?'
   },
   message_type: Facebook::Messenger::Bot::MessagingType::UPDATE
-}, access_token: ENV['ACCESS_TOKEN'], app_secret_proof: app_secret_proof)
+}, access_token: ENV['ACCESS_TOKEN'], app_secret_proof: app_secret_proof
+)
 ```
 NOTE: for a provider you can get the `app_secret_proof` (from the credential_provider, which will cache it for you) like so:
 ```
 credential_provider = Facebook::Messenger::Configuration::Providers::Environment.new
 app_secret_proof = credential_provider.app_secret_proof_for(page_id)
 ```
+For methods like `reply` below and all instance methods, the `app_secret_proof` will be calculated if you set the environment variable `APP_SECRET_PROOF_ENABLED` to `true`
 
 ##### Messages with images
 

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -13,7 +13,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v2.10/me'
+      base_uri 'https://graph.facebook.com/v3.2/me'
 
       #
       # @return [Array] Array containing the supported webhook events.
@@ -39,16 +39,22 @@ module Facebook
         #
         # @param [Hash] message A Hash describing the recipient and the message.
         # @param [String] access_token Access token.
+        # @param [String] app_secret_proof proof of the app_secret
+        # https://developers.facebook.com/docs/graph-api/securing-requests/
+        # Note: we provide a helper function available at
+        # Messenger::Configuration::Providers::Base#calculate_app_secret_proof
         #
         # Returns a String describing the message ID if the message was sent,
         # or raises an exception if it was not.
-        def deliver(message, access_token:)
+        def deliver(message, access_token:, app_secret_proof: nil)
+          query = {
+            access_token: access_token
+          }
+          query[:appsecret_proof] = app_secret_proof if app_secret_proof
           response = post '/messages',
                           body: JSON.dump(message),
                           format: :json,
-                          query: {
-                            access_token: access_token
-                          }
+                          query: query
 
           Facebook::Messenger::Bot::ErrorParser.raise_errors_from(response)
 

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -13,7 +13,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v2.9/me'
+      base_uri 'https://graph.facebook.com/v2.10/me'
 
       #
       # @return [Array] Array containing the supported webhook events.

--- a/lib/facebook/messenger/configuration/app_secret_proof_calculator.rb
+++ b/lib/facebook/messenger/configuration/app_secret_proof_calculator.rb
@@ -1,10 +1,9 @@
 module Facebook
   module Messenger
     class Configuration
-      # The helpers module provides helpers that can be useful for
-      # configuration providers
-      module Helpers
-        def calculate_app_secret_proof(app_secret, access_token)
+      # We provide a service to calculate an app_secret_proof
+      class AppSecretProofCalculator
+        def self.call(app_secret, access_token)
           OpenSSL::HMAC.hexdigest(
             OpenSSL::Digest.new('SHA256'.freeze),
             app_secret,

--- a/lib/facebook/messenger/configuration/helpers.rb
+++ b/lib/facebook/messenger/configuration/helpers.rb
@@ -1,0 +1,17 @@
+module Facebook
+  module Messenger
+    class Configuration
+      # The helpers module provides helpers that can be useful for
+      # configuration providers
+      module Helpers
+        def calculate_app_secret_proof(app_secret, access_token)
+          OpenSSL::HMAC.hexdigest(
+            OpenSSL::Digest.new('SHA256'.freeze),
+            app_secret,
+            access_token
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/configuration/providers/base.rb
+++ b/lib/facebook/messenger/configuration/providers/base.rb
@@ -1,4 +1,4 @@
-require 'facebook/messenger/configuration/helpers'
+require 'facebook/messenger/configuration/app_secret_proof_calculator'
 
 module Facebook
   module Messenger
@@ -9,8 +9,6 @@ module Facebook
         #   Be sure to implement all the functions as it raises
         #   NotImplementedError errors.
         class Base
-          include Facebook::Messenger::Configuration::Helpers
-
           # A default caching implentation of generating the app_secret_proof
           # for a given page_id
           def app_secret_proof_for(page_id = nil)
@@ -34,6 +32,13 @@ module Facebook
           end
 
           private
+
+          def calculate_app_secret_proof(app_secret, access_token)
+            Facebook::Messenger::Configuration::AppSecretProofCalculator.call(
+              app_secret,
+              access_token
+            )
+          end
 
           def memoized_app_secret_proofs
             @memoized_app_secret_proofs ||= {}

--- a/lib/facebook/messenger/configuration/providers/base.rb
+++ b/lib/facebook/messenger/configuration/providers/base.rb
@@ -14,11 +14,11 @@ module Facebook
           # A default caching implentation of generating the app_secret_proof
           # for a given page_id
           def app_secret_proof_for(page_id = nil)
-            app_secret = app_secret_for(page_id)
-            access_token = access_token_for(page_id)
-            @cached_app_secret_proof ||= {}
-            @cached_app_secret_proof[[app_secret, access_token]] =
-              calculate_app_secret_proof(app_secret, access_token)
+            return unless fetch_app_secret_proof_enabled?
+
+            memo_key = [app_secret_for(page_id), access_token_for(page_id)]
+            memoized_app_secret_proofs[memo_key] ||=
+              calculate_app_secret_proof(*memo_key)
           end
 
           def valid_verify_token?(*)
@@ -31,6 +31,16 @@ module Facebook
 
           def access_token_for(*)
             raise NotImplementedError
+          end
+
+          private
+
+          def memoized_app_secret_proofs
+            @memoized_app_secret_proofs ||= {}
+          end
+
+          def fetch_app_secret_proof_enabled?
+            false
           end
         end
       end

--- a/lib/facebook/messenger/configuration/providers/base.rb
+++ b/lib/facebook/messenger/configuration/providers/base.rb
@@ -1,3 +1,5 @@
+require 'facebook/messenger/configuration/helpers'
+
 module Facebook
   module Messenger
     class Configuration
@@ -7,6 +9,18 @@ module Facebook
         #   Be sure to implement all the functions as it raises
         #   NotImplementedError errors.
         class Base
+          include Facebook::Messenger::Configuration::Helpers
+
+          # A default caching implentation of generating the app_secret_proof
+          # for a given page_id
+          def app_secret_proof_for(page_id)
+            app_secret = app_secret_for(page_id)
+            access_token = access_token_for(page_id)
+            @cached_app_secret_proof ||= {}
+            @cached_app_secret_proof[[app_secret, access_token]] =
+              calculate_app_secret_proof(app_secret, access_token)
+          end
+
           def valid_verify_token?(*)
             raise NotImplementedError
           end

--- a/lib/facebook/messenger/configuration/providers/base.rb
+++ b/lib/facebook/messenger/configuration/providers/base.rb
@@ -13,7 +13,7 @@ module Facebook
 
           # A default caching implentation of generating the app_secret_proof
           # for a given page_id
-          def app_secret_proof_for(page_id)
+          def app_secret_proof_for(page_id = nil)
             app_secret = app_secret_for(page_id)
             access_token = access_token_for(page_id)
             @cached_app_secret_proof ||= {}

--- a/lib/facebook/messenger/configuration/providers/environment.rb
+++ b/lib/facebook/messenger/configuration/providers/environment.rb
@@ -22,6 +22,10 @@ module Facebook
           def access_token_for(*)
             ENV['ACCESS_TOKEN']
           end
+
+          def fetch_app_secret_proof_enabled?
+            ENV['APP_SECRET_PROOF_ENABLED'] == 'true'.freeze
+          end
         end
       end
     end

--- a/lib/facebook/messenger/configuration/providers/environment.rb
+++ b/lib/facebook/messenger/configuration/providers/environment.rb
@@ -1,9 +1,11 @@
+require 'facebook/messenger/configuration/providers/base'
+
 module Facebook
   module Messenger
     class Configuration
       module Providers
         # The default configuration provider for environment variables.
-        class Environment
+        class Environment < Base
           def valid_verify_token?(verify_token)
             verify_token == ENV['VERIFY_TOKEN']
           end

--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -74,7 +74,9 @@ module Facebook
             sender_action: 'typing_on'
           }
 
-          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+          Facebook::Messenger::Bot.deliver(payload,
+                                           access_token: access_token,
+                                           app_secret_proof: app_secret_proof)
         end
 
         #
@@ -90,7 +92,9 @@ module Facebook
             sender_action: 'typing_off'
           }
 
-          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+          Facebook::Messenger::Bot.deliver(payload,
+                                           access_token: access_token,
+                                           app_secret_proof: app_secret_proof)
         end
 
         #
@@ -106,7 +110,9 @@ module Facebook
             sender_action: 'mark_seen'
           }
 
-          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+          Facebook::Messenger::Bot.deliver(payload,
+                                           access_token: access_token,
+                                           app_secret_proof: app_secret_proof)
         end
 
         #
@@ -123,7 +129,9 @@ module Facebook
             message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
           }
 
-          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+          Facebook::Messenger::Bot.deliver(payload,
+                                           access_token: access_token,
+                                           app_secret_proof: app_secret_proof)
         end
 
         #
@@ -133,6 +141,10 @@ module Facebook
         #
         def access_token
           Facebook::Messenger.config.provider.access_token_for(recipient)
+        end
+
+        def app_secret_proof
+          Facebook::Messenger.config.provider.app_secret_proof_for(recipient)
         end
       end
     end

--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -74,9 +74,7 @@ module Facebook
             sender_action: 'typing_on'
           }
 
-          Facebook::Messenger::Bot.deliver(payload,
-                                           access_token: access_token,
-                                           app_secret_proof: app_secret_proof)
+          deliver_payload(payload)
         end
 
         #
@@ -92,9 +90,7 @@ module Facebook
             sender_action: 'typing_off'
           }
 
-          Facebook::Messenger::Bot.deliver(payload,
-                                           access_token: access_token,
-                                           app_secret_proof: app_secret_proof)
+          deliver_payload(payload)
         end
 
         #
@@ -110,9 +106,7 @@ module Facebook
             sender_action: 'mark_seen'
           }
 
-          Facebook::Messenger::Bot.deliver(payload,
-                                           access_token: access_token,
-                                           app_secret_proof: app_secret_proof)
+          deliver_payload(payload)
         end
 
         #
@@ -129,9 +123,7 @@ module Facebook
             message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
           }
 
-          Facebook::Messenger::Bot.deliver(payload,
-                                           access_token: access_token,
-                                           app_secret_proof: app_secret_proof)
+          deliver_payload(payload)
         end
 
         #
@@ -145,6 +137,14 @@ module Facebook
 
         def app_secret_proof
           Facebook::Messenger.config.provider.app_secret_proof_for(recipient)
+        end
+
+        private
+
+        def deliver_payload(payload)
+          Facebook::Messenger::Bot.deliver(payload,
+                                           access_token: access_token,
+                                           app_secret_proof: app_secret_proof)
         end
       end
     end

--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -15,6 +15,7 @@ module Facebook
         # Return hash containing the referral information of user.
         def referral
           return if @messaging['postback']['referral'].nil?
+
           @referral ||= Referral::Referral.new(
             @messaging['postback']['referral']
           )

--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -160,6 +160,7 @@ module Facebook
           # If the application has subscribed to webhooks other than Messenger,
           # 'messaging' won't be available and it is not relevant to us.
           next unless entry['messaging'.freeze]
+
           # Facebook may batch several items in the 'messaging' array during
           # periods of high load.
           entry['messaging'.freeze].each do |messaging|

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -4,6 +4,7 @@ describe Facebook::Messenger::Bot do
   let(:verify_token) { 'verify token' }
   let(:app_secret) { 'app secret' }
   let(:access_token) { 'access token' }
+  let(:app_secret_proof) { 'app_secret_proof' }
 
   before do
     ENV['ACCESS_TOKEN'] = access_token
@@ -163,14 +164,26 @@ describe Facebook::Messenger::Bot do
           query: { access_token: access_token },
           body: payload,
           headers: { 'Content-Type' => 'application/json' }
-        )
-        .to_return(
+        ).to_return(
           body: JSON.dump(hash),
           headers: default_graph_api_response_headers
         )
     end
 
-    context 'when all is well' do
+    def stub_request_to_return_with_proof(hash)
+      stub_request(:post, messages_url)
+        .with(
+          query: { access_token: access_token,
+                   appsecret_proof: app_secret_proof },
+          body: payload,
+          headers: { 'Content-Type' => 'application/json' }
+        ).to_return(
+          body: JSON.dump(hash),
+          headers: default_graph_api_response_headers
+        )
+    end
+
+    context 'when all is well without an appsecret_proof' do
       let(:recipient_id) { '1008372609250235' }
       let(:message_id) { 'mid.1456970487936:c34767dfe57ee6e339' }
 
@@ -183,6 +196,24 @@ describe Facebook::Messenger::Bot do
 
       it 'sends a message' do
         result = subject.deliver(payload, access_token: access_token)
+        expect(result).to eq({ recipient_id: recipient_id,
+                               message_id: message_id }.to_json)
+      end
+    end
+
+    context 'when all is well with an appsecret_proof' do
+      let(:recipient_id) { '1008372609250235' }
+      let(:message_id) { 'mid.1456970487936:c34767dfe57ee6e339' }
+
+      before do
+        stub_request_to_return_with_proof(
+          recipient_id: recipient_id,
+          message_id: message_id
+        )
+      end
+
+      it 'sends a message' do
+        result = subject.deliver(payload, access_token: access_token, app_secret_proof: app_secret_proof)
         expect(result).to eq({ recipient_id: recipient_id,
                                message_id: message_id }.to_json)
       end

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -213,7 +213,9 @@ describe Facebook::Messenger::Bot do
       end
 
       it 'sends a message' do
-        result = subject.deliver(payload, access_token: access_token, app_secret_proof: app_secret_proof)
+        result = subject.deliver(payload,
+                                 access_token: access_token,
+                                 app_secret_proof: app_secret_proof)
         expect(result).to eq({ recipient_id: recipient_id,
                                message_id: message_id }.to_json)
       end

--- a/spec/facebook/messenger/configuration/providers/environment_spec.rb
+++ b/spec/facebook/messenger/configuration/providers/environment_spec.rb
@@ -39,4 +39,37 @@ describe Facebook::Messenger::Configuration::Providers::Environment do
 
     it { is_expected.to eq(access_token) }
   end
+
+  describe '.app_secret_proof_for with app_secret_proof_disabled' do
+    let(:page_id) { '123' }
+
+    subject { described_class.new.app_secret_proof_for(page_id) }
+    before { ENV['APP_SECRET_PROOF_ENABLED'] = 'false' }
+
+    it { is_expected.to eq(nil) }
+  end
+
+  describe '.app_secret_proof_for with app_secret_proof enabled' do
+    let(:page_id) { '123' }
+    let(:access_token) { 'ABC' }
+    let(:app_secret) { 'ABsecret' }
+    let(:app_secret_proof) { 'proof' }
+
+    subject { described_class.new }
+    before { ENV['ACCESS_TOKEN'] = access_token }
+    before { ENV['APP_SECRET'] = app_secret }
+    before { ENV['APP_SECRET_PROOF_ENABLED'] = 'true' }
+
+    it 'calculates the app_secret_proof' do
+      expect_any_instance_of(Facebook::Messenger::Configuration::Helpers)
+        .to(
+          receive(:calculate_app_secret_proof)
+            .once
+            .with(app_secret, access_token)
+            .and_return(app_secret_proof)
+        )
+      expect(subject.app_secret_proof_for(page_id)).to eq(app_secret_proof)
+      expect(subject.app_secret_proof_for(page_id)).to eq(app_secret_proof)
+    end
+  end
 end

--- a/spec/facebook/messenger/configuration/providers/environment_spec.rb
+++ b/spec/facebook/messenger/configuration/providers/environment_spec.rb
@@ -61,14 +61,16 @@ describe Facebook::Messenger::Configuration::Providers::Environment do
     before { ENV['APP_SECRET_PROOF_ENABLED'] = 'true' }
 
     it 'calculates the app_secret_proof' do
-      expect_any_instance_of(Facebook::Messenger::Configuration::Helpers)
+      expect(Facebook::Messenger::Configuration::AppSecretProofCalculator)
         .to(
-          receive(:calculate_app_secret_proof)
+          receive(:call)
             .once
             .with(app_secret, access_token)
             .and_return(app_secret_proof)
         )
       expect(subject.app_secret_proof_for(page_id)).to eq(app_secret_proof)
+      # call twice to test that we have cached correctly so we don't
+      # call calculate_app_secret_proof twice
       expect(subject.app_secret_proof_for(page_id)).to eq(app_secret_proof)
     end
   end

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -64,17 +64,21 @@ describe Dummy do
 
   describe '.typing_on' do
     let(:access_token) { 'access_token' }
+    let(:app_secret_proof) { 'app_secret_proof' }
 
     it 'sends a typing indicator to the sender' do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
+      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
+        .with(subject.recipient)
+        .and_return(app_secret_proof)
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
                 recipient: subject.sender,
                 sender_action: 'typing_on'
-              }, access_token: access_token)
+              }, access_token: access_token, app_secret_proof: app_secret_proof)
 
       subject.typing_on
     end
@@ -82,17 +86,21 @@ describe Dummy do
 
   describe '.typing_off' do
     let(:access_token) { 'access_token' }
+    let(:app_secret_proof) { 'app_secret_proof' }
 
     it 'sends a typing off indicator to the sender' do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
+      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
+        .with(subject.recipient)
+        .and_return(app_secret_proof)
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
                 recipient: subject.sender,
                 sender_action: 'typing_off'
-              }, access_token: access_token)
+              }, access_token: access_token, app_secret_proof: app_secret_proof)
 
       subject.typing_off
     end
@@ -100,17 +108,21 @@ describe Dummy do
 
   describe '.mark_seen' do
     let(:access_token) { 'access_token' }
+    let(:app_secret_proof) { 'app_secret_proof' }
 
     it 'sends a typing off indicator to the sender' do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
+      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
+        .with(subject.recipient)
+        .and_return(app_secret_proof)
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
                 recipient: subject.sender,
                 sender_action: 'mark_seen'
-              }, access_token: access_token)
+              }, access_token: access_token, app_secret_proof: app_secret_proof)
 
       subject.mark_seen
     end
@@ -118,18 +130,22 @@ describe Dummy do
 
   describe '.reply' do
     let(:access_token) { 'access_token' }
+    let(:app_secret_proof) { 'app_secret_proof' }
 
     it 'replies to the sender with the default message type' do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
+      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
+        .with(subject.recipient)
+        .and_return(app_secret_proof)
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
                 recipient: subject.sender,
                 message: { text: 'Hello, human' },
                 message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
-              }, access_token: access_token)
+              }, access_token: access_token, app_secret_proof: app_secret_proof)
 
       subject.reply(text: 'Hello, human')
     end

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -62,121 +62,72 @@ describe Dummy do
     end
   end
 
-  describe '.typing_on' do
+  describe 'responding to message' do
     let(:access_token) { 'access_token' }
     let(:app_secret_proof) { 'app_secret_proof' }
-
-    it 'sends a typing indicator to the sender' do
-      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
-        .with(subject.recipient)
-        .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to(
-        receive(:app_secret_proof_for)
-          .with(subject.recipient)
-          .and_return(app_secret_proof)
+    before do
+      allow(Facebook::Messenger.config.provider).to(
+        receive(:access_token_for)
+          .with(subject.recipient).and_return(access_token)
       )
-
-      expect(Facebook::Messenger::Bot).to receive(:deliver)
-        .with({
-                recipient: subject.sender,
-                sender_action: 'typing_on'
-              }, access_token: access_token, app_secret_proof: app_secret_proof)
-
-      subject.typing_on
-    end
-  end
-
-  describe '.typing_on with app_secret_proof disabled' do
-    let(:access_token) { 'access_token' }
-
-    it 'sends a typing indicator to the sender' do
-      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
-        .with(subject.recipient)
-        .and_return(access_token)
-
-      expect(Facebook::Messenger.config.provider).to receive(:fetch_app_secret_proof_enabled?)
-                                                       .and_return(nil)
-
-      expect(Facebook::Messenger::Bot).to receive(:deliver)
-        .with({
-                recipient: subject.sender,
-                sender_action: 'typing_on'
-              }, access_token: access_token, app_secret_proof: nil)
-
-      subject.typing_on
-    end
-  end
-
-  describe '.typing_off' do
-    let(:access_token) { 'access_token' }
-    let(:app_secret_proof) { 'app_secret_proof' }
-
-    it 'sends a typing off indicator to the sender' do
-      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
-        .with(subject.recipient)
-        .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to(
+      allow(Facebook::Messenger.config.provider).to(
         receive(:app_secret_proof_for)
-          .with(subject.recipient)
-          .and_return(app_secret_proof)
+          .with(subject.recipient).and_return(app_secret_proof)
       )
-
-      expect(Facebook::Messenger::Bot).to receive(:deliver)
-        .with({
-                recipient: subject.sender,
-                sender_action: 'typing_off'
-              }, access_token: access_token, app_secret_proof: app_secret_proof)
-
-      subject.typing_off
     end
-  end
+    shared_examples_for 'payload delivery' do |delivery_method|
+      shared_examples_for 'request execution' do
+        it 'delivers the payload' do
+          expect(Facebook::Messenger::Bot).to receive(:deliver)
+            .with(
+              payload,
+              access_token: access_token,
+              app_secret_proof: app_secret_proof
+            )
+          subject.public_send(delivery_method)
+        end
+      end
 
-  describe '.mark_seen' do
-    let(:access_token) { 'access_token' }
-    let(:app_secret_proof) { 'app_secret_proof' }
-
-    it 'sends a typing off indicator to the sender' do
-      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
-        .with(subject.recipient)
-        .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to(
-        receive(:app_secret_proof_for)
-          .with(subject.recipient)
-          .and_return(app_secret_proof)
-      )
-
-      expect(Facebook::Messenger::Bot).to receive(:deliver)
-        .with({
-                recipient: subject.sender,
-                sender_action: 'mark_seen'
-              }, access_token: access_token, app_secret_proof: app_secret_proof)
-
-      subject.mark_seen
-    end
-  end
-
-  describe '.reply' do
-    let(:access_token) { 'access_token' }
-    let(:app_secret_proof) { 'app_secret_proof' }
-
-    it 'replies to the sender with the default message type' do
-      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
-        .with(subject.recipient)
-        .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to(
-        receive(:app_secret_proof_for)
-          .with(subject.recipient)
-          .and_return(app_secret_proof)
-      )
-
-      expect(Facebook::Messenger::Bot).to receive(:deliver)
-        .with({
-                recipient: subject.sender,
-                message: { text: 'Hello, human' },
-                message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
-              }, access_token: access_token, app_secret_proof: app_secret_proof)
-
-      subject.reply(text: 'Hello, human')
+      context 'when app secret proof enabled' do
+        include_examples 'request execution'
+      end
+      context 'when app secret proof disabled' do
+        let(:app_secret_proof) { nil }
+        include_examples 'request execution'
+      end
+      it_behaves_like 'payload delivery', :typing_on do
+        let(:payload) do
+          {
+            recipient: subject.sender,
+            sender_action: 'typing_on'
+          }
+        end
+      end
+      it_behaves_like 'payload delivery', :typing_off do
+        let(:payload) do
+          {
+            recipient: subject.sender,
+            sender_action: 'typing_off'
+          }
+        end
+      end
+      it_behaves_like 'payload delivery', :mark_seen do
+        let(:payload) do
+          {
+            recipient: subject.sender,
+            sender_action: 'mark_seen'
+          }
+        end
+      end
+      it_behaves_like 'payload_delivery', :reply do
+        let(:payload) do
+          {
+            recipient: subject.sender,
+            message: { text: 'Hello, human' },
+            message_type: Facebook::Messenger::Bot::MessageType::RESPONSE
+          }
+        end
+      end
     end
   end
 end

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -86,6 +86,27 @@ describe Dummy do
     end
   end
 
+  describe '.typing_on with app_secret_proof disabled' do
+    let(:access_token) { 'access_token' }
+
+    it 'sends a typing indicator to the sender' do
+      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
+        .with(subject.recipient)
+        .and_return(access_token)
+
+      expect(Facebook::Messenger.config.provider).to receive(:fetch_app_secret_proof_enabled?)
+                                                       .and_return(nil)
+
+      expect(Facebook::Messenger::Bot).to receive(:deliver)
+        .with({
+                recipient: subject.sender,
+                sender_action: 'typing_on'
+              }, access_token: access_token, app_secret_proof: nil)
+
+      subject.typing_on
+    end
+  end
+
   describe '.typing_off' do
     let(:access_token) { 'access_token' }
     let(:app_secret_proof) { 'app_secret_proof' }

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -70,9 +70,11 @@ describe Dummy do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
-        .with(subject.recipient)
-        .and_return(app_secret_proof)
+      expect(Facebook::Messenger.config.provider).to(
+        receive(:app_secret_proof_for)
+          .with(subject.recipient)
+          .and_return(app_secret_proof)
+      )
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
@@ -92,9 +94,11 @@ describe Dummy do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
-        .with(subject.recipient)
-        .and_return(app_secret_proof)
+      expect(Facebook::Messenger.config.provider).to(
+        receive(:app_secret_proof_for)
+          .with(subject.recipient)
+          .and_return(app_secret_proof)
+      )
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
@@ -114,9 +118,11 @@ describe Dummy do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
-        .with(subject.recipient)
-        .and_return(app_secret_proof)
+      expect(Facebook::Messenger.config.provider).to(
+        receive(:app_secret_proof_for)
+          .with(subject.recipient)
+          .and_return(app_secret_proof)
+      )
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({
@@ -136,9 +142,11 @@ describe Dummy do
       expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
         .with(subject.recipient)
         .and_return(access_token)
-      expect(Facebook::Messenger.config.provider).to receive(:app_secret_proof_for)
-        .with(subject.recipient)
-        .and_return(app_secret_proof)
+      expect(Facebook::Messenger.config.provider).to(
+        receive(:app_secret_proof_for)
+          .with(subject.recipient)
+          .and_return(app_secret_proof)
+      )
 
       expect(Facebook::Messenger::Bot).to receive(:deliver)
         .with({


### PR DESCRIPTION
Fixes https://github.com/jgorset/facebook-messenger/issues/239

So this was more work than I thought when I first looked in, due to not wanting to recalculate a hash on every request, here is an outline on the thoughts behind this:

* appsecret_proof is a hash, so we don't want to calculate it on every request
* deliver needs appsecret_proof and is also used internally by other classes
* Common will need to cache the appsecret_proof to avoid redo-ing the work. so we need a default way of calculating this on the credential provider
* deliver itself is a class method, and so probably shouldn't be doing the caching by itself, so it takes in a raw `appsecret_proof` by itself.

One possible extension is to have an environment_variable or something on the credential provider like `ENV['USE_APP_SECRET_PROOF']` so that people can opt out of it in the `common` methods like `reply` and `typing_on`, (currently this will always happen).

Thoughts?