### PR TITLE
clear cached body on new request

### DIFF
--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -23,6 +23,8 @@ module Facebook
 
       # Rack handler for request.
       def call(env)
+        @body = nil
+        @parsed_body = nil
         @request = Rack::Request.new(env)
         @response = Rack::Response.new
 


### PR DESCRIPTION
I've found that in my simple bot only first message from fb-messenger was successful, each later message got message integrity error. When I insert cleaning of `@body` and `@parsed_body` all become ok.