### PR TITLE
feat: expose response and API usage headers

### DIFF
--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -45,7 +45,7 @@ module Facebook
         #
         # Returns a String describing the message ID if the message was sent,
         # or raises an exception if it was not.
-        def deliver(message, page_id:)
+        def deliver(message, page_id:, return_response: false)
           access_token = config.provider.access_token_for(page_id)
           app_secret_proof = config.provider.app_secret_proof_for(page_id)
 
@@ -58,6 +58,8 @@ module Facebook
                           query: query
 
           Facebook::Messenger::Bot::ErrorParser.raise_errors_from(response)
+
+          return response if return_response
 
           response.body
         end

--- a/lib/facebook/messenger/bot/error_parser.rb
+++ b/lib/facebook/messenger/bot/error_parser.rb
@@ -45,6 +45,9 @@ module Facebook
             error_code = error['code']
             error_subcode = error['error_subcode']
 
+            error.merge!('app-usage' => response.headers['x-app-usage'],
+                         'buc-usage' => response.headers['x-business-use-case-usage'])
+
             raise_code_only_error(error_code, error) if error_subcode.nil?
 
             raise_code_subcode_error(error_code, error_subcode, error)

--- a/lib/facebook/messenger/error.rb
+++ b/lib/facebook/messenger/error.rb
@@ -12,6 +12,8 @@ module Facebook
       attr_reader :user_title
       attr_reader :user_msg
       attr_reader :fbtrace_id
+      attr_reader :buc_usage
+      attr_reader :app_usage
 
       #
       # Constructor function.
@@ -26,6 +28,8 @@ module Facebook
         @user_title = error['error_user_title']
         @user_msg = error['error_user_msg']
         @fbtrace_id = error['fbtrace_id']
+        @buc_usage = error['buc-usage']
+        @app_usage = error['app-usage']
       end
 
       #

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -227,6 +227,16 @@ describe Facebook::Messenger::Bot do
         expect(result).to eq({ recipient_id: recipient_id,
                                message_id: message_id }.to_json)
       end
+
+      context 'with option `return_response`' do
+        it 'sends a message and return response' do
+          response = subject.deliver(payload, page_id: page_id, return_response: true)
+
+          expect(response.body).to eq({ recipient_id: recipient_id,
+                                        message_id: message_id }.to_json)
+          expect(response.headers).to eq(default_graph_api_response_headers)
+        end
+      end
     end
 
     context 'when Facebook had an internal server error' do

--- a/spec/helpers/graph_api_helpers.rb
+++ b/spec/helpers/graph_api_helpers.rb
@@ -1,5 +1,7 @@
 def default_graph_api_response_headers
   {
-    'Content-Type' => 'text/javascript; charset=UTF-8'
+    'Content-Type' => 'text/javascript; charset=UTF-8',
+    'x-business-use-case-usage' => "{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}",
+    'x-app-usage' => "{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}"
   }
 end


### PR DESCRIPTION
according to rate limit  doc https://developers.facebook.com/docs/graph-api/overview/rate-limiting, we can get `app usage` or `Business Use Case(buc) usage` from API request.

so i add two features here - 

1. make deliver method can get request headers
```ruby
response = Facebook::Messenger::Bot.deliver(message_obj, ... , return_response: true)
response.body 
# => "{\"recipient_id\":\"...\",\"message_id\":\"...\"}"
response.headers['x-business-use-case-usage']
# => "{\"YOUR_PAGE_ID\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}"
```

2. ensure exception object can get usage headers
```ruby
# case 1
begin
  response = Facebook::Messenger::Bot.deliver({}, ...)
  # <Facebook::Messenger::Bot::BadParameterError: (#100) The parameter recipient is required (subcode: )>
rescue Facebook::Messenger::FacebookError => e
  e.code
  # => 100
  e.buc_usage
  # => nil
  e.app_usage
  # => "{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}"
end

# case 2
begin
  response = Facebook::Messenger::Bot.deliver(message_obj, ... )
  # (#613) Calls to this api have exceeded the rate limit
rescue Facebook::Messenger::LimitError => e
  e.code
  # => 613
  e.buc_usage
  # => {\"YOUR_PAGE_ID\":[{\"type\":\"pages\",\"call_count\":107,\"total_cputime\":1,\"total_time\":125,\"estimated_time_to_regain_access\":1406}]}

  # NOTE: estimated_time_to_regain_access -> Time, in minutes, until calls will not longer be throttled.
```

